### PR TITLE
Ignore ssl error when loading images in phantomjs

### DIFF
--- a/lib/markdown-pdf.js
+++ b/lib/markdown-pdf.js
@@ -127,6 +127,7 @@ function markdownpdf(opts) {
         // Invoke phantom to generate the PDF
         var childArgs = [
             path.join(__dirname, "..", "lib-phantom", "markdown-pdf.js")
+          , "--ignore-ssl-errors=true"
           , tmpHtmlPath
           , tmpPdfPath
           , opts.runningsPath

--- a/lib/markdown-pdf.js
+++ b/lib/markdown-pdf.js
@@ -126,8 +126,8 @@ function markdownpdf(opts) {
       htmlToTmpHtmlFile.on("finish", function() {
         // Invoke phantom to generate the PDF
         var childArgs = [
-            path.join(__dirname, "..", "lib-phantom", "markdown-pdf.js")
-          , "--ignore-ssl-errors=true"
+            "--ignore-ssl-errors=true"
+          , path.join(__dirname, "..", "lib-phantom", "markdown-pdf.js")
           , tmpHtmlPath
           , tmpPdfPath
           , opts.runningsPath


### PR DESCRIPTION
This is kind of hack to fix the issue of missing images in generated pdf, it works for me. Kindly review and feedback. 
